### PR TITLE
Dockerfileでの命令順を変更

### DIFF
--- a/server/docker/Dockerfile
+++ b/server/docker/Dockerfile
@@ -7,10 +7,10 @@ ENV GO111MODULE=on
 
 WORKDIR /workdir
 
-COPY go.mod  ./
-RUN go mod download
-
 COPY . .
+
+# 本来なら依存のダウンロードは「COPY . .」より先に行うべきだが，ホストの方で上書きするとうまく動かない場合があるようなのでこの順番にしている
+RUN go mod tidy -v
 RUN go build -o batoru .
 
 FROM gcr.io/distroless/static-debian10:latest


### PR DESCRIPTION
close #21

ちょっとキャッシュ効率悪いけど `go mod tidy -v`を`COPY . . `の後にやるように