### PR TITLE
nginxをhttps-portalに変更してhttps対応

### DIFF
--- a/build/nginx/baetoru.ssl.conf.erb
+++ b/build/nginx/baetoru.ssl.conf.erb
@@ -1,0 +1,41 @@
+upstream backend{
+    server app:8080;
+}
+
+upstream frontend{
+    server front:3000;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name <%= domain.name %>;
+
+    client_max_body_size 50M;
+
+    ssl_certificate <%= domain.chained_cert_path %>;
+    ssl_certificate_key <%= domain.key_path %>;
+
+    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+    ssl_session_cache shared:SSL:50m;
+    ssl_ciphers ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA;
+    ssl_prefer_server_ciphers on;
+    ssl_session_timeout 10m;
+
+    ssl_dhparam <%= dhparam_path %>;
+
+    location /api{
+       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+       proxy_set_header Host $http_host;
+       proxy_redirect off;
+       proxy_set_header X-Forwarded-Proto $scheme;
+       proxy_pass http://backend;
+    }
+
+    location / {
+       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+       proxy_set_header Host $http_host;
+       proxy_redirect off;
+       proxy_set_header X-Forwarded-Proto $scheme;
+       proxy_pass http://frontend;
+    }
+}

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,18 +1,18 @@
 version: "3"
 services:
   nginx:
-    image: nginx:1.19.9-alpine
+    image: steveltn/https-portal:1.20.1
     restart: always
     ports:
       - 80:80
       - 443:443
     volumes:
       # Nginxの設定ファイルを上書きする
-      - ./build/nginx/local.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./build/nginx/nginx.conf:/etc/nginx/nginx.conf
-    #      - ./docker/nginx/conf/key.pem:/etc/ssl/private/key.pem:ro
-    #      - ./docker/nginx/conf/cert.pem:/etc/ssl/certs/cert.pem:ro
-    #      - ./docker/nginx/conf/dhparam.pem:/etc/nginx/ssl/dhparam.pem
+      - ./build/nginx/baetoru.ssl.conf.erb:/var/lib/nginx-conf/localhost.ssl.conf.erb:ro
+      - https-portal-data:/var/lib/https-portal
+    environment:
+      STAGE: local
+      DOMAINS: "localhost"
     depends_on:
       - app
       - front
@@ -75,6 +75,7 @@ services:
 volumes:
   db-data:
   ignore:
+  https-portal-data:
 
 networks:
   baetoru-network:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,18 +1,18 @@
-version: '3'
+version: "3"
 services:
   nginx:
-    image: nginx:1.19.9-alpine
+    image: steveltn/https-portal:1.20.1
     restart: always
     ports:
       - 80:80
       - 443:443
     volumes:
       # Nginxの設定ファイルを上書きする
-      - ./build/nginx/baetoru.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./build/nginx/nginx.conf:/etc/nginx/nginx.conf
-#      - ./docker/nginx/conf/key.pem:/etc/ssl/private/key.pem:ro
-#      - ./docker/nginx/conf/cert.pem:/etc/ssl/certs/cert.pem:ro
-#      - ./docker/nginx/conf/dhparam.pem:/etc/nginx/ssl/dhparam.pem
+      - ./build/nginx/baetoru.ssl.conf.erb:/var/lib/nginx-conf/baetoru.ssl.conf.erb:ro
+      - https-portal-data:/var/lib/https-portal
+    environment:
+      STAGE: "production"
+      DOMAINS: "baetoru.tetsuzawa.com"
     depends_on:
       - app
       - front
@@ -57,17 +57,18 @@ services:
       - baetoru-network
 
   front:
-      build:
-        context: ./frontend/
-        dockerfile: docker/prod/Dockerfile
-      command: npm run start
-      environment:
-        - .env.prod
-      networks:
-        - baetoru-network
+    build:
+      context: ./frontend/
+      dockerfile: docker/prod/Dockerfile
+    command: npm run start
+    environment:
+      - .env.prod
+    networks:
+      - baetoru-network
 
 volumes:
   db-data:
+  https-portal-data:
 
 networks:
   baetoru-network:


### PR DESCRIPTION
### これはなに
ACMから証明書をダウンロードするのが無理だったので，https-portal(nginx + Let's Encrypt)を使ってhttps化
### 申し送り
本番環境で動くか試してないです

なぜかs3からcorsエラーが返ってくるんですが， #69 でクライアントからs3に投げなくなるので問題ない...かな？