### PR TITLE
無限ローディングをホーム画面で

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -6,7 +6,7 @@ import { PhotosProps, PhotoType } from '../src/types';
 import { useIntersection } from '../src/hooks/useIntersection';
 
 const getPhotos = async (page: number) => {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_HOST}/api/v1/photos/search?page=${page}&perPage=8`);
+  const res = await fetch(`${process.env.NEXT_PUBLIC_HOST}/api/v1/photos/search?page=${page}&perPage=16`);
   return await res.json();
 };
 
@@ -58,7 +58,7 @@ const Home = (props: PhotosProps): JSX.Element => {
 export const getServerSideProps = async (): Promise<{
   props: PhotosProps;
 }> => {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_SSR_HOST}/api/v1/photos/search?page=0&perPage=8`);
+  const res = await fetch(`${process.env.NEXT_PUBLIC_SSR_HOST}/api/v1/photos/search?page=0&perPage=16`);
   const data = (await res.json());
 
   return {


### PR DESCRIPTION
close #{issue番号}

### これはなに

無限ローディングをホーム画面に追加。
`GetPhotos` ではなく、`SearchPhotos` にパラメータ渡さずにリクエストを投げればそれっぽいレスポンスが来るので、page だけ指定してリクエストを投げた。  


### 申し送り
実験的に8つずつ取得するようにしてあります。